### PR TITLE
Fix exportEmailsToAzureSearch pipeline failure

### DIFF
--- a/solutions/projectstaffing/deployment/arm/data-factory/pipelines.json
+++ b/solutions/projectstaffing/deployment/arm/data-factory/pipelines.json
@@ -1886,7 +1886,14 @@
                     {
                         "name": "exportEmailsToAzureSearch",
                         "type": "Copy",
-                        "dependsOn": [],
+                        "dependsOn": [
+                            {
+                                "activity": "ThereIsContentToExport",
+                                "dependencyConditions": [
+                                    "Succeeded"
+                                ]
+                            }
+                        ],
                         "policy": {
                             "timeout": "7.00:00:00",
                             "retry": 0,
@@ -2237,6 +2244,53 @@
                                 }
                             }
                         ]
+                    },
+                    {
+                        "name": "ThereIsContentToExport",
+                        "type": "Validation",
+                        "dependsOn": [],
+                        "userProperties": [],
+                        "typeProperties": {
+                            "dataset": {
+                                "referenceName": "EnrichedEmailsForIndexing",
+                                "type": "DatasetReference",
+                                "parameters": {
+                                    "batchTimeBasedSubpath": {
+                                        "value": "@pipeline().parameters.batchTimeBasedSubpath",
+                                        "type": "Expression"
+                                    },
+                                    "azbsContainer": {
+                                        "value": "@pipeline().globalParameters.gdc_emails_azbs_container",
+                                        "type": "Expression"
+                                    }
+                                }
+                            },
+                            "timeout": "0.00:00:05",
+                            "sleep": 2,
+                            "childItems": true
+                        }
+                    },
+                    {
+                        "name": "Do nothing",
+                        "type": "Wait",
+                        "dependsOn": [
+                            {
+                                "activity": "ThereIsContentToExport",
+                                "dependencyConditions": [
+                                    "Failed"
+                                ]
+                            },
+                            {
+                                "activity": "exportEmailsToAzureSearch",
+                                "dependencyConditions": [
+                                    "Skipped"
+                                ]
+                            }
+                        ],
+                        "userProperties": [],
+                        "typeProperties": {
+                            "waitTimeInSeconds": 1
+                        }
                     }
                 ],
                 "parameters": {


### PR DESCRIPTION
The exportEmailsToAzureSearch pipeline was failing because in the configured input path there were no files. This is cause by the fact that mail_enrichment_processor.py script doesn't generate an output file if the input file is empty.

I thought that the beast solution would be to address the problem in ADF since it's an ADF issue, instead of hacking the script to write an empty file. So I added a validation stage validation for input files existence, before exporting emails to Azure Search.

This approach might be questionable. I got inspiration from here :https://docs.microsoft.com/en-us/answers/questions/73250/adf-can-validation-activity-timeout-be-suppressed.html .

The attached image shows how the exportEmailsToAzureSearch pipeline looks after adding the validation step.

The "Do nothing" activity and the skip link from "exportEmailsToAzureSearch" to "Do nothing" activity are necessary in order for the entire exportEmailsToAzureSearch pipeline to not fail if there are no files in the input path.

<img width="563" alt="exportEmailsToAzureSearch" src="https://user-images.githubusercontent.com/62558039/116425507-02ec8280-a84b-11eb-89a2-848cdae40e49.png">
