### PR TITLE
Adding pipeline reference to MGDC101_recurring_trigger.json

### DIFF
--- a/solutions/conversation-lineage/arm/End2EndMgdc101WithConvLineage/trigger/MGDC101_recurring_trigger.json
+++ b/solutions/conversation-lineage/arm/End2EndMgdc101WithConvLineage/trigger/MGDC101_recurring_trigger.json
@@ -1,6 +1,12 @@
 {
     "name": "MGDC101_recurring_trigger",
     "properties": {
+		"pipeline": {
+			"pipelineReference": {
+				"referenceName": "End2EndMgdc101WithConvLineage",
+				"type": "PipelineReference"
+			}
+        },
         "annotations": [],
         "runtimeState": "Stopped",
         "type": "TumblingWindowTrigger",


### PR DESCRIPTION
Adding the pipeline reference to the recurring trigger so that the End2EndMgdc101WithConvLineage pipeline will be linked to the MGDC101_recurring_trigger upon deployment of the trigger.