### PR TITLE
Fixing indentation

### DIFF
--- a/solutions/conversation-lineage/arm/End2EndMgdc101WithConvLineage/trigger/MGDC101_recurring_trigger.json
+++ b/solutions/conversation-lineage/arm/End2EndMgdc101WithConvLineage/trigger/MGDC101_recurring_trigger.json
@@ -1,11 +1,11 @@
 {
     "name": "MGDC101_recurring_trigger",
     "properties": {
-		"pipeline": {
-			"pipelineReference": {
-				"referenceName": "End2EndMgdc101WithConvLineage",
-				"type": "PipelineReference"
-			}
+	"pipeline": {
+		"pipelineReference": {
+			"referenceName": "End2EndMgdc101WithConvLineage",
+			"type": "PipelineReference"
+		}
         },
         "annotations": [],
         "runtimeState": "Stopped",


### PR DESCRIPTION
Inadvertantly added an extra tab for the pipeline property. Removing the indent.