### PR TITLE
Updated "Azure API Notes and Documentation" section

### DIFF
--- a/solutions/conversation-lineage/conversations_text_analytics/README.MD
+++ b/solutions/conversation-lineage/conversations_text_analytics/README.MD
@@ -216,7 +216,7 @@ JSON documents in the request body typically include an ID, text, and language c
 
 Maximum size of a single document: 5,120 characters
 
-Maximum size of a single document: 125K characters
+Maximum size of a single document (`/analyze` endpoint): 125K characters
 
 Applies to Sentiment Analysis, Opinion Mining, and Key Phrase Extraction
 


### PR DESCRIPTION
The notes around the Maximum size of a single document was unclear as currently stated. I updated to distinguish the 5,120 character limitation from the 125k character limit (/analyze) max size, which aligns with the Microsoft documentation.