### PR TITLE
Fix for azure-storage-blob version missing in maven central

### DIFF
--- a/solutions/projectstaffing/deployment/arm/data-factory/pipelines.json
+++ b/solutions/projectstaffing/deployment/arm/data-factory/pipelines.json
@@ -1212,7 +1212,7 @@
                                 },
                                 {
                                     "pypi": {
-                                        "package": "azure-storage-blob==12.5.0"
+                                        "package": "azure-storage-blob==12.7.0"
                                     }
                                 },
                                 {
@@ -1534,7 +1534,7 @@
                                 },
                                 {
                                     "pypi": {
-                                        "package": "azure-storage-blob==12.5.0"
+                                        "package": "azure-storage-blob==12.7.0"
                                     }
                                 },
                                 {
@@ -1761,7 +1761,7 @@
                                 },
                                 {
                                     "pypi": {
-                                        "package": "azure-storage-blob==12.5.0"
+                                        "package": "azure-storage-blob==12.7.0"
                                     }
                                 },
                                 {
@@ -2380,7 +2380,7 @@
                                 },
                                 {
                                     "pypi": {
-                                        "package": "azure-storage-blob==12.5.0"
+                                        "package": "azure-storage-blob==12.7.0"
                                     }
                                 },
                                 {
@@ -5030,7 +5030,7 @@
                                 },
                                 {
                                     "pypi": {
-                                        "package": "azure-storage-blob==12.5.0"
+                                        "package": "azure-storage-blob==12.7.0"
                                     }
                                 },
                                 {

--- a/solutions/projectstaffing/deployment/arm/scripts/cluster_libraries.json
+++ b/solutions/projectstaffing/deployment/arm/scripts/cluster_libraries.json
@@ -6,7 +6,7 @@
   },
   {
     "pypi": {
-      "package": "azure-storage-blob==12.5.0"
+      "package": "azure-storage-blob==12.7.0"
     }
   },
   {

--- a/solutions/projectstaffing/jgraph/core/pom.xml
+++ b/solutions/projectstaffing/jgraph/core/pom.xml
@@ -169,7 +169,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
-            <version>12.6.0</version>
+            <version>12.7.0</version>
         </dependency>
 
         <!-- Elasticsearch -->

--- a/solutions/projectstaffing/pygraph/azure_processing/requirements.txt
+++ b/solutions/projectstaffing/pygraph/azure_processing/requirements.txt
@@ -6,7 +6,7 @@ azure-keyvault==4.1.0
 azure-keyvault-certificates==4.2.1
 azure-keyvault-keys==4.3.1
 azure-keyvault-secrets==4.2.0
-azure-storage-blob==12.6.0
+azure-storage-blob==12.7.0
 databricks-connect==6.6.0
 dill==0.3.3
 gensim==3.8.0

--- a/solutions/projectstaffing/pygraph/azure_processing/requirements_conda.txt
+++ b/solutions/projectstaffing/pygraph/azure_processing/requirements_conda.txt
@@ -7,7 +7,7 @@ azure-keyvault==4.1.0
 azure-keyvault-certificates==4.2.1
 azure-keyvault-keys==4.3.1
 azure-keyvault-secrets==4.2.0
-azure-storage-blob==12.6.0
+azure-storage-blob==12.7.0
 databricks-connect==6.6.0
 dill==0.3.3
 gensim==3.8.0


### PR DESCRIPTION
All artifacts for azure-storage-blob versions prior to 12.7.0 are now missing from Maven Central. Only metadata remains.
Problem already reported in https://github.com/Azure/azure-sdk-for-java/issues/23616. 
Incremented version to 12.7.0 to fix the problem, as that is closest version which still has artifacts present in maven central.