### PR TITLE
Correcting struct attribute name casing

### DIFF
--- a/Datasets/data-connect-dataset-message1.md
+++ b/Datasets/data-connect-dataset-message1.md
@@ -55,12 +55,12 @@ The Message_v1 dataset can be joined with User datasets, Mail folder datasets an
 | subject  |string | The subject of the message. | No | None |
 | importance | string | The importance of the message. *Allowed values:* Low = 0, Normal = 1, High = 2. | No | None |
 | parentFolderId | string | The unique identifier for the message's parent folder. | No | None |
-| sender | object | The account that is actually used to generate the message. *Format:* `STRUCT<EmailAddress: STRUCT<Name: STRING, Address: STRING>>.` | No | None |
-| from | object | The mailbox owner and sender of the message. *Format:* `STRUCT<EmailAddress: STRUCT<Name: STRING, Address: STRING>>.` | No | None |
-| toRecipients | array | The To recipients for the message. *Format:* `ARRAY<STRUCT<EmailAddress: STRUCT<Name: STRING, Address: STRING>>>.` | No | None |
-| ccRecipients | array | The Cc recipients for the message. *Format:* `ARRAY<STRUCT<EmailAddress: STRUCT<Name: STRING, Address: STRING>>>.` | No | None |
-| bccRecipients | array | The Bcc recipients for the message. *Format:* `ARRAY<STRUCT<EmailAddress: STRUCT<Name: STRING, Address: STRING>>>.` | No | None |
-| replyTo | array | The email addresses to use when replying. *Format:* `ARRAY<STRUCT<EmailAddress: STRUCT<Name: STRING, Address: STRING>>>.` | No | None |
+| sender | object | The account that is actually used to generate the message. *Format:* `STRUCT<emailAddress: STRUCT<name: STRING, address: STRING>>.` | No | None |
+| from | object | The mailbox owner and sender of the message. *Format:* `STRUCT<emailAddress: STRUCT<name: STRING, address: STRING>>.` | No | None |
+| toRecipients | array | The To recipients for the message. *Format:* `ARRAY<STRUCT<emailAddress: STRUCT<name: STRING, address: STRING>>>.` | No | None |
+| ccRecipients | array | The Cc recipients for the message. *Format:* `ARRAY<STRUCT<emailAddress: STRUCT<name: STRING, address: STRING>>>.` | No | None |
+| bccRecipients | array | The Bcc recipients for the message. *Format:* `ARRAY<STRUCT<emailAddress: STRUCT<name: STRING, address: STRING>>>.` | No | None |
+| replyTo | array | The email addresses to use when replying. *Format:* `ARRAY<STRUCT<emailAddress: STRUCT<name: STRING, address: STRING>>>.` | No | None |
 | conversationId | string | The ID of the conversation the email belongs to. | No | None |
 | uniqueBody | object | The body of the message that is unique to the conversation. *Format:* `STRUCT<ContentType: INT32, Content: STRING>.` | No | None |
 | isDeliveryReceiptRequested | boolean | Indicates whether a read receipt is requested for the message. | No | None |
@@ -73,12 +73,12 @@ The Message_v1 dataset can be joined with User datasets, Mail folder datasets an
 | changeKey |string | The version of the message. | No | None |
 | categories | array | The categories associated with the message. *Format:* `ARRAY<STRING>.` | No | None |
 | id | string | The unique identifier of the message. | No | None |
-| attachments | array | The 'FileAttachment' and 'ItemAttachment' attachments for the message; Navigation property. *Format:* `ARRAY<STRUCT<LastModifiedDateTime: STRING, Name: STRING, ContentType: STRING, Size: INT, IsInline: BOOLEAN, Id: STRING>>.` | No | None |
+| attachments | array | The 'FileAttachment' and 'ItemAttachment' attachments for the message; Navigation property. *Format:* `ARRAY<STRUCT<lastModifiedDateTime: STRING, name: STRING, contentType: STRING, size: INT, isInline: BOOLEAN, id: STRING>>.` | No | None |
 | inferenceClassification | string | The classification of the message for the user, based on inferred relevance or importance, or on an explicit override. *Allowed values:* focused or other. | No | None |
 | flag | object | The flag value that indicates the status, start date, due date, or completion date for the message. | No | None |
-| body | object | The body of the message. It can be in HTML or text format. *Format:* `STRUCT<ContentType: INT32, Content: STRING>.`  | No | None |
+| body | object | The body of the message. It can be in HTML or text format. *Format:* `STRUCT<contentType: INT32, content: STRING>.`  | No | None |
 | bodyPreview | string | The first 255 characters of the message body. It is text format. | No | None |
-| internetMessageHeaders | array | A collection of message headers defined by RFC5322. The set includes message headers indicating the network path taken by a message from the sender to the recipient. It can also contain custom message headers that hold app data for the message. *Format:* `ARRAY<STRUCT<Name: STRING, Value: STRING>>>.` | No | None |
+| internetMessageHeaders | array | A collection of message headers defined by RFC5322. The set includes message headers indicating the network path taken by a message from the sender to the recipient. It can also contain custom message headers that hold app data for the message. *Format:* `ARRAY<STRUCT<name: STRING, value: STRING>>>.` | No | None |
 | conversationIndex | string | Indicates the position of the message within the conversation. | No | None |
 | ODataType | string | Data type of the current folder. | No | None |
 | puser | string | User id. | No |  None |


### PR DESCRIPTION
The case of any attribute names within the STRUCTS in the schema is incorrect and misleading. Most are incorrectly specified as PascalCase when they should be camelCase. This change corrects the casing and brings them into alignment with (most) root attribute names and sample data.