### PR TITLE
Correction of incorrect EmailAddress attribute name for SharedWith

### DIFF
--- a/Datasets/data-connect-dataset-sharepointpermissions.md
+++ b/Datasets/data-connect-dataset-sharepointpermissions.md
@@ -65,7 +65,7 @@ SharePoint sharing permissions information, showing what is being shared and who
 | SharedWith Object[] Object array with one entry for every sharing recipient |  No | False |
 | SharedWith, Type | String | Type of sharing recipient (Internal, External, SecurityGroup, SharePoint Group) |  No | False |
 | SharedWith, Name | String | Name of sharing recipient |  No | False |
-| SharedWith, EmailAddress | String | Email of sharing recipient (optional, won’t show for SharePoint groups or special security groups) |  No | False |
+| SharedWith, Email | String | Email of sharing recipient (optional, won’t show for SharePoint groups or special security groups) |  No | False |
 | ShareCreatedBy | String | The user or group that created the sharing link. <br />Format: ``STRUCT<`Type`: STRING, `Name`: STRING, `Email`: STRING>>`` |  No | False |
 | ShareCreatedTime Date The date and time when the share link was created |  No | False |
 | ShareLastModifiedBy | String | The user or group that last modified the sharing link. Format: <Struct <Type: String, Name: String, Email: String>> |  No | False |


### PR DESCRIPTION
Corrected SharedWith attribute from incorrect "EmailAddress" to corrected "Email" naming. It is now consistent with samples and actual returned data from querying GDC.