### PR TITLE
Changing Spark version to 3.4 for synapse workspace

### DIFF
--- a/ARMTemplates/MGDC Extraction Pre Reqs/azuredeploy.json
+++ b/ARMTemplates/MGDC Extraction Pre Reqs/azuredeploy.json
@@ -299,7 +299,7 @@
             ],
             "properties": {
                 "creationDate": "2021-12-15T13:50:11.03Z",
-                "sparkVersion": "3.1",
+                "sparkVersion": "3.4",
                 "nodeCount": 0,
                 "nodeSize": "Small",
                 "nodeSizeFamily": "MemoryOptimized",


### PR DESCRIPTION
Changing Spark version to 3.4 for synapse workspace. Older version of 3.1 was deprecated and cannot create any new clusters with 3.1